### PR TITLE
Set relationship type to default related to if not specified in csv

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,4 +9,4 @@ py-jama-rest-client = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.7"
+python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
-{
+    {
     "_meta": {
         "hash": {
-            "sha256": "de5d15cabf0846f046dc9373a6c9fb6b7e323dc8453b68b7159fe5e181cd7d4c"
+            "sha256": "8fdda48434ad215038e4b54a584ab51ab0c98f5d2395e302364f4ca283ce4f1f"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.9"
         },
         "sources": [
             {
@@ -18,46 +18,50 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
-                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
             ],
-            "version": "==2019.6.16"
+            "version": "==2020.12.5"
         },
         "chardet": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
-            "version": "==3.0.4"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.0.0"
         },
         "idna": {
             "hashes": [
-                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
-                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
-            "version": "==2.8"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.10"
         },
         "py-jama-rest-client": {
             "hashes": [
-                "sha256:3b6e4b4e00969fa9694008550e8817df39899c10013014b23bf53f4db09890f9",
-                "sha256:5a6146a70fc63a3df9d138a8ce4cde857b86ea51d99d10eb7eccf5c145ca9306"
+                "sha256:77771e596b273be19658acc28857f7d25a354175f947fc0440b99953e71b441c",
+                "sha256:92c7c2d98f05aa6bff2943e0eab717541ab535cbe5eb526e6f06a2941eb309db"
             ],
             "index": "pypi",
-            "version": "==1.8.0"
+            "version": "==1.14.0"
         },
         "requests": {
             "hashes": [
-                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
-                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
             ],
-            "version": "==2.22.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.25.1"
         },
         "urllib3": {
             "hashes": [
-                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
-                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+                "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80",
+                "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"
             ],
-            "version": "==1.25.3"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.3"
         }
     },
     "develop": {}

--- a/config.py
+++ b/config.py
@@ -39,7 +39,9 @@ csv_headers = []
 csv_source_column = 'SourceGuiID'
 # THe CSV column that contains the data to match the target item
 csv_target_column = 'DestGuiID'
+
 # Optional: This column can set the type of relationship to be created.
+# Set to None if relationship type does not need to be imported
 csv_relationship_type_column = 'Connector_Type'
 
 
@@ -47,7 +49,7 @@ csv_relationship_type_column = 'Connector_Type'
 #    Import settings
 ###################################################################################################
 # Setting match on custom field to False will tell the program to expect raw API ID's, this improves performance.
-match_on_custom_field = True
+match_on_custom_field = False
 
 # The name's of the custom fields to do lookup's.  This is a field on a jama item
 source_item_custom_field_name = 'ea_legacy_id'

--- a/csv_relationship_importer.py
+++ b/csv_relationship_importer.py
@@ -91,7 +91,7 @@ class CSVRelationshipImporter:
 
                 # Now get the relationship data string if it exists.
                 if relationship_type_column is not None:
-                    relationship_info = row_data[relationship_type_column]
+                    relationship_info = row_data.get(relationship_type_column)
                     current_row_rel_data['rel_type_data'] = relationship_info
 
                 # Append the data from this row to a list for processing.
@@ -172,7 +172,7 @@ class CSVRelationshipImporter:
                 try:
                     prepared_relationship['relationshipType'] = relationship['rel_type_data']
                 except KeyError:
-                    pass
+                    prepared_relationship['relationshipType'] = default_relationship_type_id
             # Append the prepared relationship to the list to be posted.
             self.prepped_relationship_data.append(prepared_relationship)
 
@@ -238,11 +238,11 @@ class CSVRelationshipImporter:
             relationship_data_present = relationship_type_coloumn in csv_dict_reader.fieldnames
             if not relationship_data_present:
                 missing_relationship_header_message = 'You have specified a relationship type header but no ' \
-                                                      'matching column was found. Please check the settings. ' \
-                                                      'specified relationship_type_column: ' \
-                                                      '{}'.format(relationship_type_coloumn)
-                CSVRelationshipImporter.logger.critical(missing_relationship_header_message)
-                raise ValueError(missing_relationship_header_message)
+                                                      'matching column was found. The ' \
+                                                      'specified relationship_type_column (' \
+                                                      '{}) will be set to the ' \
+                                                      'default value.'.format(relationship_type_coloumn)
+                CSVRelationshipImporter.logger.warning(missing_relationship_header_message)
 
     @staticmethod
     def _get_item_id_by_custom_field(field_value, field_name, lookup_table, project_list):


### PR DESCRIPTION
Resolves error caused by not specifying relationship type column in csv

- If `csv_relationship_type_column` is set in config but is missing in csv the relationship type will default to 'Related to'

- Python version requirement changed from 3.7 to 3.9

[EES-EESD-32](https://www.jamaland.com/perspective.req?docId=4573536&projectId=24331)